### PR TITLE
Update to latest main release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 ```bash
-    npx create-eth@1.0.2 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.3 -e BuidlGuidl/arbitrum-extension
 ```
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 ```bash
-    npx create-eth@1.0.0 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.1 -e BuidlGuidl/arbitrum-extension
 ```
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 ```bash
-    npx create-eth@1.0.1 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.2 -e BuidlGuidl/arbitrum-extension
 ```
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 ```bash
-    npx create-eth@1.0.0-beta.5 -e BuidlGuidl/arbitrum-extension:main
+    npx create-eth@1.0.0 -e BuidlGuidl/arbitrum-extension
 ```
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 ```bash
-    npx create-eth@1.0.3 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.4 -e BuidlGuidl/arbitrum-extension
 ```
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -3,7 +3,7 @@ export const skipQuickStart = true;
 export const extraContents = `# Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 \`\`\`bash
-    npx create-eth@1.0.0-beta.5 -e BuidlGuidl/arbitrum-extension:main
+    npx create-eth@1.0.0 -e BuidlGuidl/arbitrum-extension
 \`\`\`
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -3,7 +3,7 @@ export const skipQuickStart = true;
 export const extraContents = `# Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 \`\`\`bash
-    npx create-eth@1.0.1 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.2 -e BuidlGuidl/arbitrum-extension
 \`\`\`
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -3,7 +3,7 @@ export const skipQuickStart = true;
 export const extraContents = `# Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 \`\`\`bash
-    npx create-eth@1.0.0 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.1 -e BuidlGuidl/arbitrum-extension
 \`\`\`
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -3,7 +3,7 @@ export const skipQuickStart = true;
 export const extraContents = `# Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 \`\`\`bash
-    npx create-eth@1.0.3 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.4 -e BuidlGuidl/arbitrum-extension
 \`\`\`
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -3,7 +3,7 @@ export const skipQuickStart = true;
 export const extraContents = `# Arbitrum Extension for Scaffold-ETH 2
 This extension adds Arbitrum specific features (bridging, address table, forced transactions) to your Scaffold-ETH 2 dApp and can be installed with:
 \`\`\`bash
-    npx create-eth@1.0.2 -e BuidlGuidl/arbitrum-extension
+    npx create-eth@1.0.3 -e BuidlGuidl/arbitrum-extension
 \`\`\`
 
 If you are not familiar with Scaffold-ETH 2, you can check the [docs](https://docs.scaffoldeth.io/) and the [website](https://scaffoldeth.io/).

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,0 @@
-{
-    "scripts": {
-        "hardhat:sign-tx": "yarn workspace @se-2/hardhat sign-tx",
-        "foundry:sign-tx": "yarn workspace @se-2/foundry sign-tx"
-    }
-}

--- a/extension/packages/foundry/root.package.json
+++ b/extension/packages/foundry/root.package.json
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+        "sign-tx": "yarn workspace @se-2/foundry sign-tx"
+    }
+}

--- a/extension/packages/hardhat/root.package.json
+++ b/extension/packages/hardhat/root.package.json
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+        "sign-tx": "yarn workspace @se-2/hardhat sign-tx"
+    }
+}

--- a/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
+++ b/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
@@ -9,7 +9,7 @@ import { useScaffoldEventHistory, useScaffoldReadContract, useScaffoldWriteContr
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { getL2ChainId, getNetworkName, isChainL1 } from "~~/utils/arbitrum/utils";
 
-const DEPLOYED_ON_BLOCK = 12960000n;
+const DEPLOYED_ON_BLOCK = 173810000n;
 
 type DeployedContractsType = {
   [chainId: number]: {

--- a/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
+++ b/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
@@ -69,9 +69,6 @@ export default function AddressTableExample() {
     fromBlock: DEPLOYED_ON_BLOCK,
     watch: true,
     filters: { sender: address },
-    blockData: true,
-    transactionData: true,
-    receiptData: true,
   });
 
   const {
@@ -84,9 +81,6 @@ export default function AddressTableExample() {
     fromBlock: DEPLOYED_ON_BLOCK,
     watch: true,
     filters: { recipient: address },
-    blockData: true,
-    transactionData: true,
-    receiptData: true,
   });
 
 

--- a/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
+++ b/extension/packages/nextjs/app/address-table/_components/AddressTableExample.tsx
@@ -9,8 +9,6 @@ import { useScaffoldEventHistory, useScaffoldReadContract, useScaffoldWriteContr
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { getL2ChainId, getNetworkName, isChainL1 } from "~~/utils/arbitrum/utils";
 
-const DEPLOYED_ON_BLOCK = 173810000n;
-
 type DeployedContractsType = {
   [chainId: number]: {
     ArbAddressTableExample?: { address: string; abi: any };
@@ -66,7 +64,6 @@ export default function AddressTableExample() {
   } = useScaffoldEventHistory({
     contractName: "ArbAddressTableExample",
     eventName: "MessageSent",
-    fromBlock: DEPLOYED_ON_BLOCK,
     watch: true,
     filters: { sender: address },
   });
@@ -78,7 +75,6 @@ export default function AddressTableExample() {
   } = useScaffoldEventHistory({
     contractName: "ArbAddressTableExample",
     eventName: "MessageSent",
-    fromBlock: DEPLOYED_ON_BLOCK,
     watch: true,
     filters: { recipient: address },
   });

--- a/extension/packages/nextjs/app/forced-tx/step1/page.tsx
+++ b/extension/packages/nextjs/app/forced-tx/step1/page.tsx
@@ -71,13 +71,8 @@ export default function ForcedTxStep1() {
                   Run the following command to sign a new transaction with your deployer wallet. It is important to note
                   that this transaction will not be broadcasted, only signed.
                   <pre className="bg-base-300 p-4 rounded-lg mt-2 mb-2">
-                    <code>yarn hardhat:sign-tx</code>
+                    <code>yarn sign-tx</code>
                   </pre>
-                  Or...
-                  <pre className="bg-base-300 p-4 rounded-lg mt-2 mb-2">
-                    <code>yarn foundry:sign-tx</code>
-                  </pre>
-                  if you are using Foundry.
                 </li>
                 <li>
                   We will use this script to sign a transaction that uses one of your deployed contracts. The real magic

--- a/extension/packages/nextjs/app/forced-tx/track/page.tsx
+++ b/extension/packages/nextjs/app/forced-tx/track/page.tsx
@@ -128,10 +128,10 @@ export default function TrackTransaction() {
           }
         }
 
-        // If it's been more than 10 minutes (600 seconds) and we're still pending, start the force countdown
-        if (elapsedTime > 600 && status === TxStatus.PENDING) {
+        // If it's been more than 15 minutes (900 seconds) and we're still pending, start the force countdown
+        if (elapsedTime > 900 && status === TxStatus.PENDING) {
           if (pollToastId) notification.remove(pollToastId);
-          pollToastId = notification.warning("Transaction not found after 10 minutes. Starting force countdown.");
+          pollToastId = notification.warning("Transaction not found after 15 minutes. Starting force countdown.");
           setStatus(TxStatus.FORCE_COUNTDOWN);
           // countdown to 24hours after l1TxBlockTimestamp
           setForceCountdown(24 * 60 * 60 - elapsedTime);
@@ -144,12 +144,12 @@ export default function TrackTransaction() {
         console.log("Transaction not found, will try again:", error);
       }
       // Default is to return false unless the time limit is hit
-      // If it's been more than 10 minutes (600 seconds), start force countdown
+      // If it's been more than 15 minutes (900 seconds), start force countdown
       console.log("elapsedTime", elapsedTime);
-      if (elapsedTime > 600) {
+      if (elapsedTime > 900) {
         if (pollToastId) notification.remove(pollToastId);
         pollToastId = notification.warning(
-          "Transaction was not processed after 10 minutes. Starting countdown until you can force the transaction from L1.",
+          "Transaction was not processed after 15 minutes. Starting countdown until you can force the transaction from L1.",
         );
         setStatus(TxStatus.FORCE_COUNTDOWN);
         setForceCountdown(24 * 60 * 60 - elapsedTime); // 23:50 in seconds
@@ -451,7 +451,7 @@ export default function TrackTransaction() {
                   {status === TxStatus.FORCE_COUNTDOWN && (
                     <div className="alert alert-warning mt-4">
                       <span>
-                        Transaction not found after 10 minutes. You will be able to force the transaction to{" "}
+                        Transaction not found after 15 minutes. You will be able to force the transaction to{" "}
                         {l2ChainName || "L2"} after the countdown (24 hours).
                       </span>
                     </div>


### PR DESCRIPTION
I tested and both Foundry and Hardhat versions work with the 1.0.0 release.

I also noticed the block number was far off from the actual block number on the Arbitrum Sepolia testnet. I updated it and created a feature request in scaffold-eth-2 so that it can be updated by default based on the contract deployment time.